### PR TITLE
handle assembly slot access case

### DIFF
--- a/solidity_parser/parser.py
+++ b/solidity_parser/parser.py
@@ -848,9 +848,14 @@ class AstVisitor(SolidityVisitor):
         return self.visit(ctx.getChild(0))
 
     def visitAssemblyMember(self, ctx):
+        if type(ctx.identifier()) == list:
+            # handle the case, eg. x.slot
+            name = ctx.identifier()[0].getText()
+        else:
+            name = ctx.identifier().getText()
         return Node(ctx=ctx,
                     type='AssemblyMember',
-                    name=ctx.identifier().getText())
+                    name=name)
 
     def visitAssemblyCall(self, ctx):
         functionName = ctx.getChild(0).getText()


### PR DESCRIPTION
Handles the error described in https://github.com/sbip-sg/smart-fuzz/issues/47

Sample code to produce the error:

```solidity
pragma solidity =0.8.4;
contract Test{
    struct TokenApprovalRef {
        address value;
    }
    
    mapping(uint256 => TokenApprovalRef) private _tokenApprovals;
    
    function accessAssemblyMemberlist(uint256 _id) public view
        returns (uint256 approvedAddressSlot, address approvedAddress) {
        TokenApprovalRef storage tokenApproval = _tokenApprovals[_id];
        assembly {
            approvedAddressSlot := tokenApproval.slot // <----- tokenApproval.slot is causing the error
            approvedAddress := sload(approvedAddressSlot)
        }
    }
}
```
